### PR TITLE
NPS-8458 build using GitHub Actions and publish artifacts to GitHub Releases

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,46 @@
+#
+# Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+name: build
+
+on: [push, pull_request, workflow_dispatch]
+# workflow_dispatch should make manually triggered ci/cd possible
+# workflow file (like this) with `workflow_dispatch` after on should exist on the **master** or default branch,
+# or there will be no ui for a manual trigger. https://github.community/t/workflow-dispatch-event-not-working/128856/2
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Set up JDK 8
+        uses: actions/setup-java@v2
+        with:
+          distribution: 'zulu'
+          java-version: '8' # major or semver Java version will be acceptable, see https://github.com/marketplace/actions/setup-java-jdk#basic
+
+      - name: Build 
+        run: ./scripts/build-installer.sh
+
+      - name: Set env
+        if: github.event_name == 'push' && contains(github.ref, 'refs/tags/')
+        run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
+
+      - name: Release
+        if: github.event_name == 'push' && contains(github.ref, 'refs/tags/')
+        uses: softprops/action-gh-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          files: ./build/distributions/pravega-sensor-collector-*.tgz
+          draft: true
+          name: pravega-sensor-collector ${{ env.RELEASE_VERSION }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -41,6 +41,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          files: ./build/distributions/pravega-sensor-collector-*.tgz
+          files: ./pravega-sensor-collector/build/distributions/pravega-sensor-collector-*.tgz
           draft: true
           name: pravega-sensor-collector ${{ env.RELEASE_VERSION }}


### PR DESCRIPTION
Each push, pull_request, workflow_dispatch will trigger build
Each push with tag with trigger build and issue a draft release with name of "flink-tools $(tag_name)" and empty body