### PR TITLE
Failed files directory path resolution fix

### DIFF
--- a/pravega-sensor-collector/src/main/java/io/pravega/sensor/collector/file/FileIngestService.java
+++ b/pravega-sensor-collector/src/main/java/io/pravega/sensor/collector/file/FileIngestService.java
@@ -124,14 +124,14 @@ public abstract class FileIngestService extends DeviceDriver {
     }
 
     protected void watchFiles() {
-        log.info("watchFiles: BEGIN");
+        log.trace("watchFiles: BEGIN");
         try {
             processor.watchFiles();
         } catch (Exception e) {
             log.error("watchFiles: watch file error", e);
             // Continue on any errors. We will retry on the next iteration.
         }
-        log.info("watchFiles: END");
+        log.trace("watchFiles: END");
     }
     protected void processFiles() {
         log.trace("processFiles: BEGIN");

--- a/pravega-sensor-collector/src/main/java/io/pravega/sensor/collector/file/FileProcessor.java
+++ b/pravega-sensor-collector/src/main/java/io/pravega/sensor/collector/file/FileProcessor.java
@@ -123,7 +123,7 @@ public abstract class FileProcessor {
     protected List<FileNameWithOffset> getDirectoryListing() throws IOException {
         log.debug("getDirectoryListing: fileSpec={}", config.fileSpec);
         //Invalid files will be moved to a separate folder Failed_Files next to the database file
-        String failedFilesDirectory = config.stateDatabaseFileName.substring(0, config.stateDatabaseFileName.lastIndexOf('/'));
+        Path failedFilesDirectory = Paths.get(config.stateDatabaseFileName).getParent();
         final List<FileNameWithOffset> directoryListing = FileUtils.getDirectoryListing(config.fileSpec, config.fileExtension, failedFilesDirectory);
         log.debug("getDirectoryListing: directoryListing={}", directoryListing);
         return directoryListing;

--- a/pravega-sensor-collector/src/main/java/io/pravega/sensor/collector/file/FileProcessor.java
+++ b/pravega-sensor-collector/src/main/java/io/pravega/sensor/collector/file/FileProcessor.java
@@ -102,7 +102,7 @@ public abstract class FileProcessor {
             // If nextFile is null then check for new files to process is handled as part of scheduleWithDelay
             final Pair<FileNameWithOffset, Long> nextFile = state.getNextPendingFileRecord();
             if (nextFile == null) {
-                log.info("processNewFiles: No more files to watch");
+                log.debug("processNewFiles: No more files to watch");
                 break;
             } else {
                 processFile(nextFile.getLeft(), nextFile.getRight());

--- a/pravega-sensor-collector/src/main/java/io/pravega/sensor/collector/util/FileUtils.java
+++ b/pravega-sensor-collector/src/main/java/io/pravega/sensor/collector/util/FileUtils.java
@@ -19,6 +19,7 @@ public class FileUtils {
 
     private static final Logger log = LoggerFactory.getLogger(FileUtils.class);
     final static String separator = ",";
+    final static String failedFiles = "Failed_Files";
 
     /**
      * @return list of file name and file size in bytes
@@ -93,7 +94,7 @@ public class FileUtils {
     Move failed files to different directory
      */
     static void moveFailedFile(FileNameWithOffset fileEntry, Path failedFilesDirectory) throws IOException {
-        Path targetPath = failedFilesDirectory.resolve("Failed_Files");
+        Path targetPath = failedFilesDirectory.resolve(failedFiles);
         Files.createDirectories(targetPath);
         //Obtain a lock on file before moving
         try(FileChannel channel = FileChannel.open(Paths.get(fileEntry.fileName), StandardOpenOption.WRITE)) {

--- a/pravega-sensor-collector/src/main/java/io/pravega/sensor/collector/util/FileUtils.java
+++ b/pravega-sensor-collector/src/main/java/io/pravega/sensor/collector/util/FileUtils.java
@@ -28,7 +28,7 @@ public class FileUtils {
      *  3. check for empty file, log the message and continue with valid files
      *
      */
-    static public List<FileNameWithOffset> getDirectoryListing(String fileSpec, String fileExtension, String failedFilesDirectory) throws IOException {
+    static public List<FileNameWithOffset> getDirectoryListing(String fileSpec, String fileExtension, Path failedFilesDirectory) throws IOException {
         String[] directories= fileSpec.split(separator);
         List<FileNameWithOffset> directoryListing = new ArrayList<>();
         for (String directory : directories) {
@@ -45,7 +45,7 @@ public class FileUtils {
     /**
      * @return get all files in directory(including subdirectories) and their respective file size in bytes
      */
-    static protected void getDirectoryFiles(Path pathSpec, String fileExtension, List<FileNameWithOffset> directoryListing, String failedFilesDirectory) throws IOException{        
+    static protected void getDirectoryFiles(Path pathSpec, String fileExtension, List<FileNameWithOffset> directoryListing, Path failedFilesDirectory) throws IOException{        
         try(DirectoryStream<Path> dirStream=Files.newDirectoryStream(pathSpec)){
             for(Path path: dirStream){
                 if(Files.isDirectory(path))         //traverse subdirectories
@@ -92,8 +92,8 @@ public class FileUtils {
     /*
     Move failed files to different directory
      */
-    static void moveFailedFile(FileNameWithOffset fileEntry, String failedFilesDirectory) throws IOException {
-        Path targetPath = Paths.get(failedFilesDirectory).resolve("Failed_Files");
+    static void moveFailedFile(FileNameWithOffset fileEntry, Path failedFilesDirectory) throws IOException {
+        Path targetPath = failedFilesDirectory.resolve("Failed_Files");
         Files.createDirectories(targetPath);
         //Obtain a lock on file before moving
         try(FileChannel channel = FileChannel.open(Paths.get(fileEntry.fileName), StandardOpenOption.WRITE)) {

--- a/pravega-sensor-collector/src/main/java/io/pravega/sensor/collector/util/TransactionCoordinator.java
+++ b/pravega-sensor-collector/src/main/java/io/pravega/sensor/collector/util/TransactionCoordinator.java
@@ -142,7 +142,7 @@ public class TransactionCoordinator {
         if (transactionsToCommit.isEmpty()) {
             log.info("performRecovery: No transactions to be recovered");
         } else {
-            log.warn("Transaction recovery needed on {} transactions", transactionsToCommit.size());
+            log.info("Transaction recovery needed on {} transactions", transactionsToCommit.size());
             transactionsToCommit.forEach((txnId) -> {
                 log.info("Committing transaction {} from a previous process", txnId);
                 try {

--- a/pravega-sensor-collector/src/test/java/io/pravega/sensor/collector/file/FileProcessorTests.java
+++ b/pravega-sensor-collector/src/test/java/io/pravega/sensor/collector/file/FileProcessorTests.java
@@ -17,6 +17,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.nio.file.Paths;
 import java.util.List;
 
 import static org.mockito.ArgumentMatchers.any;
@@ -78,7 +79,7 @@ public class FileProcessorTests {
     @Test
     public void getDirectoryListingTest() throws IOException {
         final List<FileNameWithOffset> actual = FileUtils.getDirectoryListing(
-                "../log-file-sample-data/","csv","");
+                "../log-file-sample-data/","csv",Paths.get("."));
         log.info("actual={}", actual);
     }
 

--- a/pravega-sensor-collector/src/test/java/io/pravega/sensor/collector/file/parquet/ParquetEventGeneratorTests.java
+++ b/pravega-sensor-collector/src/test/java/io/pravega/sensor/collector/file/parquet/ParquetEventGeneratorTests.java
@@ -15,6 +15,7 @@ import io.pravega.sensor.collector.util.PravegaWriterEvent;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -24,7 +25,7 @@ public class ParquetEventGeneratorTests {
     @Test
     public void TestFile() throws IOException {
         final EventGenerator eventGenerator = ParquetEventGenerator.create("routingKey1",100);
-        final List<FileNameWithOffset> files = FileUtils.getDirectoryListing("../parquet-file-sample-data","parquet","");
+        final List<FileNameWithOffset> files = FileUtils.getDirectoryListing("../parquet-file-sample-data","parquet",Paths.get("."));
         File parquetData= new File(files.get(0).fileName);
 
         final CountingInputStream inputStream = new CountingInputStream(new FileInputStream(parquetData));


### PR DESCRIPTION
This PR updates the code to extract the parent directory for Failed_Files folder. Path.getParent() method is used to make it platform independent.