### PR TITLE
Load logback for windows

### DIFF
--- a/windows-service/PravegaSensorCollectorApp.xml
+++ b/windows-service/PravegaSensorCollectorApp.xml
@@ -18,7 +18,7 @@
 
   <!-- Use the below commented tag to load custom logback.xml -->
 
-  <!-- <arguments>-Xmx512m -Dlogback.configurationFile=logback.xml -jar "windows-service\PSCFiles\pravega-sensor-collector-0.2.15.jar"</arguments> -->
+  <!-- <arguments>-Xmx512m -Dlogback.configurationFile=.\logback.xml -jar "windows-service\PSCFiles\pravega-sensor-collector-0.2.15.jar"</arguments> -->
 
   <!-- old log files are truncated when service restarts. Can change logmode to append, roll-by-size and roll-by-time -->
   <logmode>reset</logmode>

--- a/windows-service/PravegaSensorCollectorApp.xml
+++ b/windows-service/PravegaSensorCollectorApp.xml
@@ -15,7 +15,11 @@
   <description>Pravega Sensor Collector collects data from sensors and ingests the data into Pravega streams</description>
   <executable>"C:/Program Files/Java/jdk-11/bin/java"</executable>
   <arguments>-Xmx512m -jar "windows-service\PSCFiles\pravega-sensor-collector-0.2.15.jar"</arguments>
-  
+
+  <!-- Use the below commented tag to load custom logback.xml -->
+
+  <!-- <arguments>-Xmx512m -Dlogback.configurationFile=logback.xml -jar "windows-service\PSCFiles\pravega-sensor-collector-0.2.15.jar"</arguments> -->
+
   <!-- old log files are truncated when service restarts. Can change logmode to append, roll-by-size and roll-by-time -->
   <logmode>reset</logmode>
 


### PR DESCRIPTION
Change log description
User can specify the path of the logback file to load it.

Purpose of the change
Ability to load logback.xml for windows

What the code does
Ability specify the path for logback file

How to verify it
You can try to load logback with DEBUG mode enabled and you should see DEBUG output in the log file.