### PR TITLE
Making file extension mandatory

### DIFF
--- a/pravega-sensor-collector/src/main/java/io/pravega/sensor/collector/DeviceDriver.java
+++ b/pravega-sensor-collector/src/main/java/io/pravega/sensor/collector/DeviceDriver.java
@@ -39,7 +39,7 @@ public abstract class DeviceDriver extends AbstractService implements AutoClosea
     public String getProperty(String key) {
         final String value = config.getProperties().get(key);
         if (value == null || value.isEmpty()) {
-            throw new IllegalArgumentException(MessageFormat.format("Missing required parameter {0}", key));
+            throw new IllegalArgumentException(MessageFormat.format("PSC Service Error: Missing required parameter {0} in config", key));
         }
         return value;
     }

--- a/pravega-sensor-collector/src/main/java/io/pravega/sensor/collector/file/FileIngestService.java
+++ b/pravega-sensor-collector/src/main/java/io/pravega/sensor/collector/file/FileIngestService.java
@@ -92,7 +92,7 @@ public abstract class FileIngestService extends DeviceDriver {
         return getProperty(FILE_SPEC_KEY);
     }
     String getFileExtension() {
-        return getProperty(FILE_EXT, "");
+        return getProperty(FILE_EXT);
     }
 
     boolean getDeleteCompletedFiles() {


### PR DESCRIPTION
Change log description
File extension is optional parameter but when we try to process parquet file using CsvFileIngestService class, it throws parsing error when it tries to process parquet file.

Purpose of the change
Fixes error while processing parquet file while using CsvFileServiceIngestService

What the code does?
Makes FILE_EXTENSION mandatory field.

How to verify it
PSC service should start without error and respective drivers should be able to process respective file extension without error and move files with different extensions to failed files folder.
